### PR TITLE
update setup.py, exclude 'test'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    packages=find_packages(),
+    packages=find_packages('test','test.*'),
     keywords="plant sensor bluetooth low-energy ble",
     zip_safe=False,
     install_requires=["btlewrap==0.0.10"],


### PR DESCRIPTION
otherwise it would try to install 'test' at top level.

```
>>> Emerging (1 of 1) dev-python/miflora-0.7.0::HomeAssistantRepository
>>> Failed to emerge dev-python/miflora-0.7.0, Log file:
>>>  '/var/tmp/portage/dev-python/miflora-0.7.0/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.25, 0.14, 0.11
 * Package:    dev-python/miflora-0.7.0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   daniel@matuschek.net
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking miflora-0.7.0.tar.gz to /var/tmp/portage/dev-python/miflora-0.7.0/work
>>> Source unpacked in /var/tmp/portage/dev-python/miflora-0.7.0/work
>>> Preparing source in /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0 ...
locale: Cannot set LC_ALL to default locale: No such file or directory
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
running build
running build_py
creating /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora
copying miflora/miflora_poller.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora
copying miflora/miflora_scanner.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora
copying miflora/__init__.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora
copying miflora/_version.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora
copying miflora/_static_version.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora
creating /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test
creating /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests
copying test/unit_tests/test_miflora_poller.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests
copying test/unit_tests/test_parse.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests
copying test/unit_tests/__init__.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests
copying test/unit_tests/test_versioncheck.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests
copying test/unit_tests/test_miflora_scanner.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests
creating /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/no_imports
copying test/no_imports/test_noimports.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/no_imports
copying test/no_imports/__init__.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/no_imports
creating /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests
copying test/integration_tests/test_gatttool_backend.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests
copying test/integration_tests/test_pygatt_backend.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests
copying test/integration_tests/test_demo.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests
copying test/integration_tests/test_everything.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests
copying test/integration_tests/__init__.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests
copying test/integration_tests/test_bluepy_backend.py -> /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests
running egg_info
writing miflora.egg-info/PKG-INFO
writing dependency_links to miflora.egg-info/dependency_links.txt
writing requirements to miflora.egg-info/requires.txt
writing top-level names to miflora.egg-info/top_level.txt
reading manifest file 'miflora.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'miflora.egg-info/SOURCES.txt'
warning: _build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/miflora-0.7.0

>>> Install dev-python/miflora-0.7.0 into /var/tmp/portage/dev-python/miflora-0.7.0/image
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install
python3.9 setup.py install --skip-build --root=/var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9
running install
running install_lib
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests/test_miflora_poller.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests/test_parse.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests/__init__.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests/test_versioncheck.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/unit_tests/test_miflora_scanner.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/no_imports
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/no_imports/test_noimports.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/no_imports
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/no_imports/__init__.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/no_imports
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests/test_gatttool_backend.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests/test_pygatt_backend.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests/test_demo.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests/test_everything.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests/__init__.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/test/integration_tests/test_bluepy_backend.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests
creating /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora/miflora_poller.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora/miflora_scanner.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora/__init__.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora/_version.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora
copying /var/tmp/portage/dev-python/miflora-0.7.0/work/miflora-0.7.0-python3_9/lib/miflora/_static_version.py -> /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/test_miflora_poller.py to test_miflora_poller.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/test_parse.py to test_parse.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/test_versioncheck.py to test_versioncheck.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/unit_tests/test_miflora_scanner.py to test_miflora_scanner.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/no_imports/test_noimports.py to test_noimports.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/no_imports/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_gatttool_backend.py to test_gatttool_backend.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_pygatt_backend.py to test_pygatt_backend.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_demo.py to test_demo.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_everything.py to test_everything.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/test/integration_tests/test_bluepy_backend.py to test_bluepy_backend.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora/miflora_poller.py to miflora_poller.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora/miflora_scanner.py to miflora_scanner.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora/_version.py to _version.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora/_static_version.py to _static_version.cpython-39.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/miflora-0.7.0/temp/tmp3htdd6f4.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/miflora-0.7.0/temp/tmp3htdd6f4.py
removing /var/tmp/portage/dev-python/miflora-0.7.0/temp/tmp3htdd6f4.py
writing byte-compilation script '/var/tmp/portage/dev-python/miflora-0.7.0/temp/tmpvus4xuad.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/miflora-0.7.0/temp/tmpvus4xuad.py
removing /var/tmp/portage/dev-python/miflora-0.7.0/temp/tmpvus4xuad.py
running install_egg_info
running egg_info
writing miflora.egg-info/PKG-INFO
writing dependency_links to miflora.egg-info/dependency_links.txt
writing requirements to miflora.egg-info/requires.txt
writing top-level names to miflora.egg-info/top_level.txt
reading manifest file 'miflora.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'miflora.egg-info/SOURCES.txt'
Copying miflora.egg-info to /var/tmp/portage/dev-python/miflora-0.7.0/image/_python3.9/usr/lib/python3.9/site-packages/miflora-0.7.0-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/miflora-0.7.0::HomeAssistantRepository failed (install phase):
 *   Package installs 'test' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2845:  Called distutils-r1_src_install
 *   environment, line 1182:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  453:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2520:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2051:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2049:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  767:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1150:  Called distutils-r1_python_install
 *   environment, line 1053:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
```