### PR TITLE
Bump btlewrap dependency to 0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 bluepy==1.3.0
 pygatt==3.2.0
-btlewrap==0.0.10
+btlewrap==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     packages=find_packages(exclude=["test", "test.*"]),
     keywords="plant sensor bluetooth low-energy ble",
     zip_safe=False,
-    install_requires=["btlewrap==0.0.10"],
+    install_requires=["btlewrap>=0.0.10,<0.2"],
     extras_require={"testing": ["pytest"]},
     include_package_data=True,
 )


### PR DESCRIPTION
Fixes #163
Release notes: https://github.com/ChristianKuehnel/btlewrap/releases/tag/v0.1.0
Compare view: https://github.com/ChristianKuehnel/btlewrap/compare/v0.0.10...v0.1.0

`0.1.0` didn't change existing APIs. Although I can't test it myself unfortunately, I would be reasonable confident that it will work.